### PR TITLE
Add support for symbol fetching errors

### DIFF
--- a/alembic/versions/a75b7537cf2d_add_symbol_exists_to_stocknames_table.py
+++ b/alembic/versions/a75b7537cf2d_add_symbol_exists_to_stocknames_table.py
@@ -1,0 +1,26 @@
+"""add symbol exists to stocknames table
+
+Revision ID: a75b7537cf2d
+Revises: 384002e1513a
+Create Date: 2022-04-16 11:51:47.601964
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Column
+
+
+# revision identifiers, used by Alembic.
+revision = 'a75b7537cf2d'
+down_revision = '384002e1513a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('stock_names', Column('symbol_exists', sa.Boolean(), nullable=True, default=False))
+
+
+def downgrade():
+    op.drop_column('stock_names', 'symbol_exists')
+

--- a/models/db/schema.py
+++ b/models/db/schema.py
@@ -10,6 +10,7 @@ class StockName(Base):
     id = Column(Integer, primary_key=True, nullable=True)
     stock_name = Column(String, nullable=False)
     symbol = Column(String, nullable=True)
+    symbol_exists = Column(Boolean, nullable=True, default=False)
     details_url = Column(String, nullable=False)
     sector_id = Column(Integer, nullable=False)
     created_at = Column(TIMESTAMP, nullable=False, server_default=text('now()'))


### PR DESCRIPTION
Symbols don't exist for all the stocks, so it is unnecessary to try to fetch each time we want to update the symbols for the new stocks which have been added to the db. So by introducing a new column in the stock names table called symbol_exists, wchih acts as a flag, we can avoid trying to scrap the symbols over and over again for the stocks which don't have symbols